### PR TITLE
Remove bogdanp/racket-http-easy for now

### DIFF
--- a/.github/workflows/autofixer-bogdanp.yml
+++ b/.github/workflows/autofixer-bogdanp.yml
@@ -14,7 +14,6 @@ jobs:
           - {repository: racket-actor, package: actor-lib}
           - {repository: racket-sentry, package: sentry-lib}
           - {repository: koyo-sentry, package: koyo-sentry}
-          - {repository: racket-http-easy, package: http-easy-lib}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
(I could've sworn I already made this PR, but I guess not?)

This change removes the http-easy repo for now to avoid repeating the same PR over and over.